### PR TITLE
Split controller and action with dot for action controller integration

### DIFF
--- a/integration/multiverse/rails42_app/test/integration/vitals_flow_test.rb
+++ b/integration/multiverse/rails42_app/test/integration/vitals_flow_test.rb
@@ -32,9 +32,9 @@ class VitalsFlowTest < ActionDispatch::IntegrationTest
   test "get posts with rack middleware" do
     get '/posts'
     metrics = %w{
-      controllers.posts_index.get.200.all
-      controllers.posts_index.get.200.db
-      controllers.posts_index.get.200.view
+      controllers.posts.index.get.200.all
+      controllers.posts.index.get.200.db
+      controllers.posts.index.get.200.view
       requests.posts_index.get.200
     }
 
@@ -49,9 +49,9 @@ class VitalsFlowTest < ActionDispatch::IntegrationTest
 
     metrics = %w{
       jobs.default.foobarcleanup
-      controllers.posts_new.get.200.all
-      controllers.posts_new.get.200.db
-      controllers.posts_new.get.200.view
+      controllers.posts.new.get.200.all
+      controllers.posts.new.get.200.db
+      controllers.posts.new.get.200.view
       requests.posts_new.get.200
     }
 
@@ -66,9 +66,9 @@ class VitalsFlowTest < ActionDispatch::IntegrationTest
     get '/posts'
 
     metrics = %w{
-      controllers.posts_index.get.200.all
-      controllers.posts_index.get.200.db
-      controllers.posts_index.get.200.view
+      controllers.posts.index.get.200.all
+      controllers.posts.index.get.200.db
+      controllers.posts.index.get.200.view
       requests.posts_index.get.200
     }
 
@@ -82,8 +82,8 @@ class VitalsFlowTest < ActionDispatch::IntegrationTest
     post '/posts', post: { title: 'foobar'}
 
     metrics = %w{
-      controllers.posts_create.post.302.all
-      controllers.posts_create.post.302.db
+      controllers.posts.create.post.302.all
+      controllers.posts.create.post.302.db
       requests.posts_create.post.302
     }
 

--- a/lib/vitals/integrations/notifications/action_controller.rb
+++ b/lib/vitals/integrations/notifications/action_controller.rb
@@ -15,7 +15,7 @@ module Vitals::Integrations::Notifications
       ctrl    = payload[:controller].sub(/Controller$/, '').downcase
       # format  = payload[:format]
 
-      m = "controllers.#{ctrl}_#{action}.#{method}.#{status}"
+      m = "controllers.#{ctrl}.#{action}.#{method}.#{status}"
       Vitals.timing("#{m}.all", duration(started, finished))
       Vitals.timing("#{m}.db", payload[:db_runtime]) if payload[:db_runtime]
       Vitals.timing("#{m}.view", payload[:view_runtime]) if payload[:view_runtime]

--- a/spec/vitals/integrations/notifications/action_controller_spec.rb
+++ b/spec/vitals/integrations/notifications/action_controller_spec.rb
@@ -31,15 +31,15 @@ describe Vitals::Integrations::Notifications::ActionController do
 
     reporter.reports.count.must_equal(3)
     report = reporter.reports[0]
-    report[:timing].must_equal('controllers.registrations_new.get.200.all')
+    report[:timing].must_equal('controllers.registrations.new.get.200.all')
     report[:val].must_be_within_delta(100, 50)
-    
+
     report = reporter.reports[1]
-    report[:timing].must_equal('controllers.registrations_new.get.200.db')
+    report[:timing].must_equal('controllers.registrations.new.get.200.db')
     report[:val].must_equal(12)
-    
+
     report = reporter.reports[2]
-    report[:timing].must_equal('controllers.registrations_new.get.200.view')
+    report[:timing].must_equal('controllers.registrations.new.get.200.view')
     report[:val].must_equal(30)
   end
 end


### PR DESCRIPTION
This is follow-up to https://github.com/jondot/vitals/commit/ae18dccc4680ea51234ae016cf5ba6c5bed23686 that started using dot syntax instead of underscores, but for some reason controller and action are still bundled together. This prevents possibility to observe i.e. all actions for single controller.